### PR TITLE
allow higher precision float numbers

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -205,9 +205,9 @@ def extract_price_text(price: str) -> Optional[str]:
 _search_decimal_sep = re.compile(r"""
 \d           # at least one digit (there can be more before it)
 ([.,€])      # decimal separator
-(?:          # 1,2 or 4 digits. 3 digits is likely to be a thousand separator.
+(?:          # 1,2 or 4+ digits. 3 digits is likely to be a thousand separator.
    \d{1,2}|
-   \d{4}
+   \d{4,8}
 )
 $
 """, re.VERBOSE).search

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -53,6 +53,10 @@ class Example(Price):
 PRICE_PARSING_EXAMPLES_BUGS_CAUGHT = [
     Example(None, 'US$:12.99',
             'US$', '12.99', 12.99),
+    Example('GBP', '34.992001',
+            'GBP', '34.992001', 34.992001),
+    Example('GBP', '29.1583',
+            'GBP', '29.1583', 29.1583),
 ]
 
 


### PR DESCRIPTION
On https://www.uktoolcentre.co.uk/xms18adjust3-bahco-adjustable-wrench-triple-pack.html website in semantic markup price number is written as 34.992001; price-parser thinks dot is a thousand separator, not a decimal separator. It is fixed here by making decimal separator check more permissive (but still with limits).