### PR TITLE
allow arbitrary precision

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -207,7 +207,7 @@ _search_decimal_sep = re.compile(r"""
 ([.,€])      # decimal separator
 (?:          # 1,2 or 4+ digits. 3 digits is likely to be a thousand separator.
    \d{1,2}|
-   \d{4,8}
+   \d{4}\d*
 )
 $
 """, re.VERBOSE).search

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -11,7 +11,7 @@ PRICE_PARSING_EXAMPLES_BUGS_CAUGHT are manually added examples for the bugs
 we've found in a wild; PRICE_PARSING_EXAMPLES_NEW is a list of tests for
 new features. New tests should probably go these two lists.
 """
-from typing import Optional
+from typing import Optional, Union
 from decimal import Decimal
 
 import pytest
@@ -26,11 +26,13 @@ class Example(Price):
                  price_raw: Optional[str],
                  currency: Optional[str],
                  amount_text: Optional[str],
-                 amount_float: Optional[float]) -> None:
+                 amount_float: Optional[Union[float, Decimal]]) -> None:
         self.currency_raw = currency_raw
         self.price_raw = price_raw
         amount_decimal = None  # type: Optional[Decimal]
-        if amount_float is not None:
+        if isinstance(amount_float, Decimal):
+            amount_decimal = amount_float
+        elif amount_float is not None:
             # don't use Decimal(amount_float), as this is not what
             # one usually means, because of float precision
             amount_decimal = Decimal(str(amount_float))
@@ -57,6 +59,8 @@ PRICE_PARSING_EXAMPLES_BUGS_CAUGHT = [
             'GBP', '34.992001', 34.992001),
     Example('GBP', '29.1583',
             'GBP', '29.1583', 29.1583),
+    Example(None, '1.11000000000000009770',
+            None, '1.11000000000000009770', Decimal('1.11000000000000009770')),
 ]
 
 


### PR DESCRIPTION
as @lopuhin noticed, we shouldn't limit amount of digits
after a decimal separator - when we don't detect decimal separator
properly it is just stripped out, causing price to be incorrect.

A follow-up to #7 :)