### PR TITLE
Improved test assertion method

### DIFF
--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -1974,7 +1974,7 @@ PRICE_PARSING_EXAMPLES_XFAIL = [
 )
 def test_parsing(example: Example):
     parsed = Price.fromstring(example.price_raw, example.currency_raw)
-    assert parsed == example
+    assert parsed == example, f"Failed scenario: price={example.price_raw}, currency_hint={example.currency_raw}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When a test fails, there are no clear indication of the input strings used for the test. This makes identifying which test case is failing very difficult.

Current:
```
    def test_parsing(example: Example):
        parsed = Price.fromstring(example.price_raw, example.currency_raw)
>       assert parsed == example
E       AssertionError: assert Price(amount=None, currency='EUR') == Example(amount=None, currency=None)
```

After this PR:
```
    def test_parsing(example: Example):
        parsed = Price.fromstring(example.price_raw, example.currency_raw)
>       assert parsed == example, f"Failed scenario: price={example.price_raw}, currency_hint={example.currency_raw}"
E       AssertionError: Failed scenario: price=SOMETHING EUROPE SOMETHING, currency_hint=None
E       assert Price(amount=None, currency='EUR') == Example(amount=None, currency=None)
```