### PR TITLE
Make quantifiers non-greedy

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -182,8 +182,8 @@ def extract_price_text(price: str) -> Optional[str]:
     """
     if price.count('€') == 1:
         m = re.search(r"""
-        [\d\s.,]*\d    # number, probably with thousand separators
-        \s*€\s*        # euro, probably separated by whitespace
+        [\d\s.,]*?\d    # number, probably with thousand separators
+        \s*?€\s*?        # euro, probably separated by whitespace
         \d\d
         (?:$|[^\d])    # something which is not a digit
         """, price, re.VERBOSE)
@@ -191,7 +191,7 @@ def extract_price_text(price: str) -> Optional[str]:
             return m.group(0).replace(' ', '')
     m = re.search(r"""
         (\d[\d\s.,]*)  # number, probably with thousand separators
-        \s*            # skip whitespace
+        \s*?            # skip whitespace
         (?:[^%\d]|$)   # capture next symbol - it shouldn't be %
         """, price, re.VERBOSE)
 
@@ -207,8 +207,8 @@ _search_decimal_sep = re.compile(r"""
 \d           # at least one digit (there can be more before it)
 ([.,€])      # decimal separator
 (?:          # 1,2 or 4+ digits. 3 digits is likely to be a thousand separator.
-   \d{1,2}|
-   \d{4}\d*
+   \d{1,2}?|
+   \d{4}\d*?
 )
 $
 """, re.VERBOSE).search


### PR DESCRIPTION
I don't think there will be any noticeable difference in the real world, but it's still the right way to write regex.
https://docs.python.org/3/howto/regex.html#greedy-versus-non-greedy
Greedy

```
%timeit re.search(r"""(\d[\d\s.,]*)\s*?(?:[^%\d]|$)""", "90 728.00 руб 103 100.00 руб", re.VERBOSE).group(1)
1.97 µs ± 200 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
Non-greedy
```
%timeit re.search(r"""(\d[\d\s.,]*)\s*(?:[^%\d]|$)""", "90 728.00 руб 103 100.00 руб", re.VERBOSE).group(1)
1.86 µs ± 103 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```