### PR TITLE
Allow to override decimal separator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,9 @@ Price(amount=Decimal('1000'), currency='EUR')
 Decimal separator
 -----------------
 
-``decimal_separator`` allows to customize it in specific cases if it is known beforehand.
+If you know which symbol is used as a decimal separator in the input string,
+pass that symbol in the ``decimal_separator`` argument to prevent price-parser
+from guessing the wrong decimal separator symbol.
 
 >>> Price.fromstring("Price: $140.600", decimal_separator=".")
 Price(amount=Decimal('140.600'), currency='$')

--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,18 @@ you can set it directly:
 Price(amount=Decimal('1000'), currency='EUR')
 
 
+Decimal separator
+-----------------
+
+``decimal_separator`` allows to customize it in specific cases if it is known beforehand.
+
+>>> Price.fromstring("Price: $140.600", decimal_separator=".")
+Price(amount=Decimal('140.600'), currency='$')
+
+>>> Price.fromstring("Price: $140.600", decimal_separator=",")
+Price(amount=Decimal('140600'), currency='$')
+
+
 Contributing
 ============
 

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -25,7 +25,8 @@ class Price:
 
     @classmethod
     def fromstring(cls, price: Optional[str],
-                   currency_hint: Optional[str] = None) -> 'Price':
+                   currency_hint: Optional[str] = None,
+                   decimal_separator_hint: Optional[str] = None) -> 'Price':
         """
         Given price and currency text extracted from HTML elements, return
         ``Price`` instance, which provides a clean currency symbol and
@@ -37,7 +38,10 @@ class Price:
         from ``currency_hint`` string.
         """
         amount_text = extract_price_text(price) if price is not None else None
-        amount_num = parse_number(amount_text) if amount_text is not None else None
+        amount_num = (
+            parse_number(amount_text, decimal_separator_hint)
+            if amount_text is not None else None
+        )
         currency = extract_currency_symbol(price, currency_hint)
         if currency is not None:
             currency = currency.strip()
@@ -234,7 +238,8 @@ def get_decimal_separator(price: str) -> Optional[str]:
         return m.group(1)
 
 
-def parse_number(num: str) -> Optional[Decimal]:
+def parse_number(num: str,
+                 decimal_separator_hint: Optional[str]) -> Optional[Decimal]:
     """ Parse a string with a number to a Decimal, guessing its format:
     decimal separator, thousand separator. Return None if parsing fails.
 
@@ -268,7 +273,10 @@ def parse_number(num: str) -> Optional[Decimal]:
     if not num:
         return None
     num = num.strip().replace(' ', '')
-    decimal_separator = get_decimal_separator(num)
+    decimal_separator = (
+        get_decimal_separator(num)
+        if not decimal_separator_hint else decimal_separator_hint
+    )
     # NOTE: Keep supported separators in sync with _search_decimal_sep
     if decimal_separator is None:
         num = num.replace('.', '').replace(',', '')

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -26,7 +26,7 @@ class Price:
     @classmethod
     def fromstring(cls, price: Optional[str],
                    currency_hint: Optional[str] = None,
-                   decimal_separator_hint: Optional[str] = None) -> 'Price':
+                   decimal_separator: Optional[str] = None) -> 'Price':
         """
         Given price and currency text extracted from HTML elements, return
         ``Price`` instance, which provides a clean currency symbol and
@@ -39,7 +39,7 @@ class Price:
         """
         amount_text = extract_price_text(price) if price is not None else None
         amount_num = (
-            parse_number(amount_text, decimal_separator_hint)
+            parse_number(amount_text, decimal_separator)
             if amount_text is not None else None
         )
         currency = extract_currency_symbol(price, currency_hint)
@@ -239,7 +239,7 @@ def get_decimal_separator(price: str) -> Optional[str]:
 
 
 def parse_number(num: str,
-                 decimal_separator_hint: Optional[str] = None) -> Optional[Decimal]:
+                 decimal_separator: Optional[str] = None) -> Optional[Decimal]:
     """ Parse a string with a number to a Decimal, guessing its format:
     decimal separator, thousand separator. Return None if parsing fails.
 
@@ -267,9 +267,9 @@ def parse_number(num: str,
     Decimal('1235.99')
     >>> parse_number("1.235€99")
     Decimal('1235.99')
-    >>> parse_number("140.000", decimal_separator_hint=",")
+    >>> parse_number("140.000", decimal_separator=",")
     Decimal('140000')
-    >>> parse_number("140.000", decimal_separator_hint=".")
+    >>> parse_number("140.000", decimal_separator=".")
     Decimal('140.000')
     >>> parse_number("")
     >>> parse_number("foo")
@@ -279,7 +279,7 @@ def parse_number(num: str,
     num = num.strip().replace(' ', '')
     decimal_separator = (
         get_decimal_separator(num)
-        if not decimal_separator_hint else decimal_separator_hint
+        if not decimal_separator else decimal_separator
     )
     # NOTE: Keep supported separators in sync with _search_decimal_sep
     if decimal_separator is None:

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -267,6 +267,10 @@ def parse_number(num: str,
     Decimal('1235.99')
     >>> parse_number("1.235€99")
     Decimal('1235.99')
+    >>> parse_number("140.000", decimal_separator_hint=",")
+    Decimal('140000')
+    >>> parse_number("140.000", decimal_separator_hint=".")
+    Decimal('140.000')
     >>> parse_number("")
     >>> parse_number("foo")
     """

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -187,8 +187,8 @@ def extract_price_text(price: str) -> Optional[str]:
     if price.count('€') == 1:
         m = re.search(r"""
         [\d\s.,]*\d    # number, probably with thousand separators
-        \s*€\s*        # euro, probably separated by whitespace
-        \d\d
+        \s*€(\s*)?     # euro, probably separated by whitespace
+        \d(?(1)\d|\d*) # if separated by whitespace - search one digit, multiple digits othervise
         (?:$|[^\d])    # something which is not a digit
         """, price, re.VERBOSE)
         if m:

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -277,10 +277,7 @@ def parse_number(num: str,
     if not num:
         return None
     num = num.strip().replace(' ', '')
-    decimal_separator = (
-        get_decimal_separator(num)
-        if not decimal_separator else decimal_separator
-    )
+    decimal_separator = decimal_separator or get_decimal_separator(num)
     # NOTE: Keep supported separators in sync with _search_decimal_sep
     if decimal_separator is None:
         num = num.replace('.', '').replace(',', '')

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -186,9 +186,9 @@ def extract_price_text(price: str) -> Optional[str]:
     """
     if price.count('€') == 1:
         m = re.search(r"""
-        [\d\s.,]*?\d    # number, probably with thousand separators
-        \s*?€(\s*?)?    # euro, probably separated by whitespace)
-        \d(?(1)\d|\d*)  # if separated by whitespace - search one digit, multiple digits othervise
+        [\d\s.,]*?\d    # number, probably with thousand separators                
+        \s*?€(\s*?)?    # euro, probably separated by whitespace
+        \d(?(1)\d|\d*?) # if separated by whitespace - search one digit, multiple digits othervise
         (?:$|[^\d])     # something which is not a digit
         """, price, re.VERBOSE)
         if m:

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -186,7 +186,7 @@ def extract_price_text(price: str) -> Optional[str]:
     """
     if price.count('€') == 1:
         m = re.search(r"""
-        [\d\s.,]*?\d    # number, probably with thousand separators                
+        [\d\s.,]*?\d    # number, probably with thousand separators
         \s*?€(\s*?)?    # euro, probably separated by whitespace
         \d(?(1)\d|\d*?) # if separated by whitespace - search one digit, multiple digits othervise
         (?:$|[^\d])     # something which is not a digit

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -239,7 +239,7 @@ def get_decimal_separator(price: str) -> Optional[str]:
 
 
 def parse_number(num: str,
-                 decimal_separator_hint: Optional[str]) -> Optional[Decimal]:
+                 decimal_separator_hint: Optional[str] = None) -> Optional[Decimal]:
     """ Parse a string with a number to a Decimal, guessing its format:
     decimal separator, thousand separator. Return None if parsing fails.
 

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -188,7 +188,7 @@ def extract_price_text(price: str) -> Optional[str]:
         m = re.search(r"""
         [\d\s.,]*?\d    # number, probably with thousand separators
         \s*?€(\s*?)?    # euro, probably separated by whitespace
-        \d(?(1)\d|\d*?) # if separated by whitespace - search one digit, multiple digits othervise
+        \d(?(1)\d|\d*?) # if separated by whitespace - search one digit, multiple digits otherwise
         (?:$|[^\d])     # something which is not a digit
         """, price, re.VERBOSE)
         if m:

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -1991,8 +1991,12 @@ def test_price_amount_float(amount, amount_float):
 @pytest.mark.parametrize(
     "price_raw,decimal_separator_hint,expected_result",
     (
+        ("140.000", None, Decimal("140000")),
         ("140.000", ",", Decimal("140000")),
         ("140.000", ".", Decimal("140.000")),
+        ("140€33", "€", Decimal("140.33")),
+        ("140,000€33", "€", Decimal("140000.33")),
+        ("140.000€33", "€", Decimal("140000.33")),
     )
 )
 def test_price_decimal_separator_hint(price_raw, decimal_separator_hint, expected_result):

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -1989,7 +1989,7 @@ def test_price_amount_float(amount, amount_float):
 
 
 @pytest.mark.parametrize(
-    "price_raw,decimal_separator_hint,expected_result",
+    "price_raw,decimal_separator,expected_result",
     (
         ("140.000", None, Decimal("140000")),
         ("140.000", ",", Decimal("140000")),
@@ -1999,9 +1999,9 @@ def test_price_amount_float(amount, amount_float):
         ("140.000€33", "€", Decimal("140000.33")),
     )
 )
-def test_price_decimal_separator_hint(price_raw, decimal_separator_hint, expected_result):
+def test_price_decimal_separator(price_raw, decimal_separator, expected_result):
     parsed = Price.fromstring(
         price_raw,
-        decimal_separator_hint=decimal_separator_hint
+        decimal_separator=decimal_separator
     )
     assert parsed.amount == expected_result

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -1971,13 +1971,6 @@ PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES = [
             '€', '1250€600', 1250.600, "€"),
 ]
 
-PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES_XFAIL = [
-    Example(None, '1250€600',
-            '€', '1250€600', 1250.600, None),
-    Example(None, '1250€ 600',
-            '€', '1250€ 600', 1250.600, None),
-]
-
 
 @pytest.mark.parametrize(
     ["example"],
@@ -1989,8 +1982,6 @@ PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES_XFAIL = [
     [[e] for e in PRICE_PARSING_EXAMPLES_NO_PRICE] +
     [[e] for e in PRICE_PARSING_EXAMPLES_NO_CURRENCY] +
     [[e] for e in PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES] +
-    [pytest.param(e, marks=pytest.mark.xfail())
-     for e in PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES_XFAIL] +
     [pytest.param(e, marks=pytest.mark.xfail())
      for e in PRICE_PARSING_EXAMPLES_XFAIL]
 )

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -26,9 +26,11 @@ class Example(Price):
                  price_raw: Optional[str],
                  currency: Optional[str],
                  amount_text: Optional[str],
-                 amount_float: Optional[Union[float, Decimal]]) -> None:
+                 amount_float: Optional[Union[float, Decimal]],
+                 decimal_separator: Optional[str] = None) -> None:
         self.currency_raw = currency_raw
         self.price_raw = price_raw
+        self.decimal_separator = decimal_separator
         amount_decimal = None  # type: Optional[Decimal]
         if isinstance(amount_float, Decimal):
             amount_decimal = amount_float
@@ -1960,6 +1962,23 @@ PRICE_PARSING_EXAMPLES_XFAIL = [
 ]
 
 
+PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES = [
+    Example(None, '1250€ 600',
+            '€', '1250', 1250, "€"),
+    Example(None, '1250€ 60',
+            '€', '1250€60', 1250.60, "€"),
+    Example(None, '1250€600',
+            '€', '1250€600', 1250.600, "€"),
+]
+
+PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES_XFAIL = [
+    Example(None, '1250€600',
+            '€', '1250€600', 1250.600, None),
+    Example(None, '1250€ 600',
+            '€', '1250€ 600', 1250.600, None),
+]
+
+
 @pytest.mark.parametrize(
     ["example"],
     [[e] for e in PRICE_PARSING_EXAMPLES_BUGS_CAUGHT] +
@@ -1969,11 +1988,14 @@ PRICE_PARSING_EXAMPLES_XFAIL = [
     [[e] for e in PRICE_PARSING_EXAMPLES_3] +
     [[e] for e in PRICE_PARSING_EXAMPLES_NO_PRICE] +
     [[e] for e in PRICE_PARSING_EXAMPLES_NO_CURRENCY] +
+    [[e] for e in PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES] +
+    [pytest.param(e, marks=pytest.mark.xfail())
+     for e in PRICE_PARSING_DECIMAL_SEPARATOR_EXAMPLES_XFAIL] +
     [pytest.param(e, marks=pytest.mark.xfail())
      for e in PRICE_PARSING_EXAMPLES_XFAIL]
 )
 def test_parsing(example: Example):
-    parsed = Price.fromstring(example.price_raw, example.currency_raw)
+    parsed = Price.fromstring(example.price_raw, example.currency_raw, example.decimal_separator)
     assert parsed == example, f"Failed scenario: price={example.price_raw}, currency_hint={example.currency_raw}"
 
 

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -1986,3 +1986,18 @@ def test_parsing(example: Example):
 )
 def test_price_amount_float(amount, amount_float):
     assert Price(amount, None, None).amount_float == amount_float
+
+
+@pytest.mark.parametrize(
+    "price_raw,decimal_separator_hint,expected_result",
+    (
+        ("140.000", ",", Decimal("140000")),
+        ("140.000", ".", Decimal("140.000")),
+    )
+)
+def test_price_decimal_separator_hint(price_raw, decimal_separator_hint, expected_result):
+    parsed = Price.fromstring(
+        price_raw,
+        decimal_separator_hint=decimal_separator_hint
+    )
+    assert parsed.amount == expected_result


### PR DESCRIPTION
Based on [#15](https://github.com/scrapinghub/price-parser/issues/15)

Add decimal_separator_hint to customize number extraction.