### PR TITLE
Added support for Python 3.13 (latest version) in tox.ini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,14 @@ jobs:
             TOXENV: py
         - python-version: "3.11"
           env:
-            TOXENV: py311
+            TOXENV: py
         - python-version: "3.12"
           env:
-            TOXENV: py312
+            TOXENV: py
         - python-version: "3.13"
           env:
-            TOXENV: py313
-        - python-version: "3.10"
+            TOXENV: py
+        - python-version: "3.13"
           env:
             TOXENV: mypy
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,19 @@ jobs:
         - python-version: "3.10"
           env:
             TOXENV: py
+        - python-version: "3.11"
+          env:
+            TOXENV: py311
+        - python-version: "3.12"
+          env:
+            TOXENV: py312
+        - python-version: "3.13"
+          env:
+            TOXENV: py313
         - python-version: "3.10"
           env:
             TOXENV: mypy
-
+        
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,6 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: mypy
-        
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,6 @@ jobs:
         
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -53,7 +53,7 @@ class Price:
         currency = extract_currency_symbol(price, currency_hint)
         if currency is not None:
             currency = currency.strip()
-        if digit_group_separator:
+        if digit_group_separator is not None and price is not None:
             price = price.replace(digit_group_separator, '')
         amount_text = extract_price_text(price) if price is not None else None
         amount_num = (

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,10 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,mypy
+envlist = py36,py37,py38,py313,mypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py313,mypy
+envlist = py36, py37, py38, py39, py310, py311, py312, py313, mypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312, py313, mypy
+envlist = py36,py37,py38,py39,py310,py311,py312,py313,mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
digit_group_separator and price is not none - make sured to make all the test passed.