### PR TITLE
fix: parse prices with leading comma decimals

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -322,7 +322,7 @@ def extract_price_text(price: str) -> Optional[str]:
         r"\s+", " ", price
     )  # clean initial text from non-breaking and extra spaces
 
-    if price.count("€") == 1:
+    if price.count("€") == 1 and not price.startswith((",", ".")):
         m = re.search(
             r"""
         [\d\s.,']*?\d    # number, probably with thousand separators
@@ -339,7 +339,7 @@ def extract_price_text(price: str) -> Optional[str]:
 
     m = re.search(
         r"""
-        ([.]?\d[\d\s.,']*)   # number, probably with thousand separators
+        ([.,]?\d[\d\s.,']*)  # number, probably with thousand separators
         \s*?                # skip whitespace
         (?:[^%\d]|$)        # capture next symbol - it shouldn't be %
         """,
@@ -350,10 +350,16 @@ def extract_price_text(price: str) -> Optional[str]:
     if m:
         price_text = m.group(1).rstrip(",.")
         price_text = price_text.replace("'", "")
+        stripped_price_text = price_text.strip()
         return (
-            price_text.strip()
-            if price_text.count(".") == 1
-            else price_text.lstrip(",.").strip()
+            stripped_price_text
+            if stripped_price_text.count(".") == 1
+            or (
+                stripped_price_text.startswith(",")
+                and stripped_price_text.count(",") == 1
+                and get_decimal_separator(stripped_price_text) == ","
+            )
+            else stripped_price_text.lstrip(",.")
         )
     if "free" in price.lower():
         return "0"

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -67,6 +67,8 @@ def idfn(val: object) -> str | None:
 
 PRICE_PARSING_EXAMPLES_BUGS_CAUGHT = [
     Example(None, "US$:12.99", "US$", "12.99", 12.99),
+    Example(None, ",89", None, ",89", 0.89),
+    Example(None, ",89 €", "€", ",89", 0.89),
     Example("GBP", "34.992001", "GBP", "34.992001", 34.992001),
     Example("GBP", "29.1583", "GBP", "29.1583", 29.1583),
     Example(


### PR DESCRIPTION
Fixes #58.

This keeps a leading comma when it is detected as the decimal separator, so inputs like `,89` and `,89 €` parse as `0.89` instead of `89`. The existing behavior for leading separators that do not look like decimals is preserved.

Verification:

```text
uv run --with pytest --with pytest-cov --with-editable . python -m pytest --cov-report=term-missing --cov-report= --cov=price_parser --doctest-modules price_parser tests README.rst -q
uv run --with ruff ruff check price_parser tests
uv run --with ruff ruff format --check price_parser tests
uv run --with mypy --with pytest --with-editable . mypy price_parser tests
git diff --check
```