### PR TITLE
Match right-to-left currency symbols without a right-to-left mark

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -77,7 +77,11 @@ parse_price = Price.fromstring
 
 def or_regex(symbols: list[str]) -> Pattern[str]:
     """Return a regex which matches any of ``symbols``"""
-    return re.compile("|".join(re.escape(s) for s in symbols))
+    # Right-to-left symbols are spelled with a trailing right-to-left mark that
+    # real-world text often omits, so any directional mark is made optional.
+    return re.compile(
+        "|".join(re.escape(s).replace("\u200f", "[\u200e\u200f]?") for s in symbols)
+    )
 
 
 # If one of these symbols is found either in price or in currency,

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -105,6 +105,16 @@ PRICE_PARSING_EXAMPLES_NEW = [
     Example(None, "644.00 جنيه", "جنيه", "644.00", 644.0),  # Egyptian pound (EGP)
     Example(None, "3,439.00 درهم", "درهم", "3,439.00", 3439.0),  # UAE dirham (AED)
     Example(None, "106.61 ريال", "ريال", "106.61", 106.61),  # Saudi riyal (SAR)
+    # Right-to-left symbols, with and without a right-to-left mark
+    Example(None, "12,999.00 ر.س.", "ر.س.", "12,999.00", 12999.0),  # SAR
+    Example(
+        None,
+        "12,999.00 ر.س.\u200f",
+        "ر.س.\u200f",
+        "12,999.00",
+        12999.0,
+    ),  # SAR
+    Example(None, "45 ج.م.", "ج.م.", "45", 45.0),  # Egyptian pound (EGP)
 ]
 
 


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/price-parser/issues/64