### PR TITLE
Support Chinese currency symbols and non-ASCII numerals

### DIFF
--- a/price_parser/_currencies.py
+++ b/price_parser/_currencies.py
@@ -1734,6 +1734,17 @@ CURRENCIES["CHF"]["sn2"] = ["Fr."]
 CURRENCIES["PLN"]["sn2"] = ["pln"]
 CURRENCIES["INR"]["sn2"] = ["₹", "र"]
 CURRENCIES["IRR"]["sn2"] = ["ریال"]
+CURRENCIES["CNY"]["sn2"] = ["元", "圆", "圓", "人民币", "人民幣"]
+# In Chinese, 元 and 圓 on their own are the yuan, but they are also the unit of
+# many foreign currencies. Those must be listed to win over 元 and 圓 alone.
+CURRENCIES["USD"]["sn2"] = ["美元", "美圓"]
+CURRENCIES["EUR"]["sn2"] = ["欧元", "歐元"]
+CURRENCIES["JPY"]["sn2"] += ["日元", "日圓"]
+CURRENCIES["HKD"]["sn2"] = ["港元", "港圓"]
+CURRENCIES["AUD"]["sn2"] = ["澳元"]
+CURRENCIES["CAD"]["sn2"] = ["加元"]
+CURRENCIES["KRW"]["sn2"] = ["韩元", "韓元"]
+CURRENCIES["SGD"]["sn2"] = ["新元", "新加坡元"]
 
 
 CURRENCY_CODES: list[str] = list(CURRENCIES.keys())

--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -1,5 +1,6 @@
 import re
 import string
+import unicodedata
 from decimal import Decimal, InvalidOperation
 from re import Pattern
 from typing import Callable, Optional
@@ -281,6 +282,32 @@ def extract_currency_symbol(
     return None
 
 
+_NON_ASCII_SEPARATORS = str.maketrans(
+    {
+        "٬": ",",  # Arabic thousands separator
+        "٫": ".",  # Arabic decimal separator
+        "，": ",",  # fullwidth comma
+        "．": ".",  # fullwidth full stop
+    }
+)
+
+
+def _to_ascii_numerals(price: str) -> str:
+    """Return *price* with its digits and separators written in ASCII.
+
+    >>> _to_ascii_numerals("۱٬۰۱۲٬۲۳۴٫۵۶")
+    '1,012,234.56'
+    """
+    if price.isascii():
+        return price
+    return "".join(
+        str(unicodedata.decimal(char))
+        if not char.isascii() and char.isdecimal()
+        else char
+        for char in price.translate(_NON_ASCII_SEPARATORS)
+    )
+
+
 def extract_price_text(price: str) -> Optional[str]:
     r"""
     Extract text of a price from a string which contains price and
@@ -321,6 +348,7 @@ def extract_price_text(price: str) -> Optional[str]:
     price = re.sub(
         r"\s+", " ", price
     )  # clean initial text from non-breaking and extra spaces
+    price = _to_ascii_numerals(price)
 
     if price.count("€") == 1:
         m = re.search(

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -105,6 +105,16 @@ PRICE_PARSING_EXAMPLES_NEW = [
     Example(None, "644.00 جنيه", "جنيه", "644.00", 644.0),  # Egyptian pound (EGP)
     Example(None, "3,439.00 درهم", "درهم", "3,439.00", 3439.0),  # UAE dirham (AED)
     Example(None, "106.61 ريال", "ريال", "106.61", 106.61),  # Saudi riyal (SAR)
+    Example(None, "22000.00元/台", "元", "22000.00", 22000.00),  # yuan (CNY)
+    Example(None, "36元人民币", "元", "36", 36),
+    Example(None, "36人民币", "人民币", "36", 36),
+    Example(None, "36美元", "美元", "36", 36),  # US dollar
+    Example(None, "36日元", "日元", "36", 36),  # Japanese yen
+    # non-ASCII digits and separators
+    Example(None, "US$ ۱٬۰۱۲٬۲۳۴٫۵۶", "US$", "1,012,234.56", 1012234.56),
+    Example(None, "￥１２，３４５", "￥", "12,345", 12345),
+    Example(None, "₹१,२३४.५६", "₹", "1,234.56", 1234.56),
+    Example(None, "12 €/m²", "€", "12", 12),
 ]
 
 
@@ -1269,7 +1279,6 @@ PRICE_PARSING_EXAMPLES_XFAIL = [
 # Valid currencies not detected by price-parser
 # Move to regular tests when added
 PRICE_PARSING_EXAMPLES_XFAIL_CURRENCIES_TO_BE_ADDED = [
-    Example(None, "22000.00元/台", "元", "22000.00", 22000.00),  # 元 is yuan
     Example(None, "2963yen", "yen", "2963", 2963),
     Example(None, "1 บาท", "บาท", "1", 1.0),  # Thai baht
     Example(None, "1 ر.س", "ر.س", "1", 1.0),  # Saudi riyal
@@ -1392,9 +1401,6 @@ PRICE_PARSING_EXAMPLES_XFAIL_CURRENCIES_TO_BE_ADDED = [
     Example(None, "1 ரூ", "ரூ", "1", 1.0),  # Sri Lankan rupee
     Example(None, "1 රු", "රු", "1", 1.0),  # Sri Lankan rupee
     Example(None, "1 ლარი", "ლარი", "1", 1.0),  # Georgian lari
-    Example(None, "1 人民币", "人民币", "1", 1.0),  # Renminbi/Chinese yuan
-    Example(None, "1 圆", "圆", "1", 1.0),  # Renminbi/Chinese yuan
-    Example(None, "1 圓", "圓", "1", 1.0),  # Renminbi/Chinese yuan
     Example(None, "1 GBp", "GBp", "1", 1.0),  # British Pound
     Example(None, "1 ￡", "￡", "1", 1.0),  # British Pound
     Example(None, "1 nzd", "nzd", "1", 1.0),  # New Zealand dollar


### PR DESCRIPTION
Fix https://github.com/scrapinghub/price-parser/issues/37.