### PR TITLE
Support typographic apostrophes as thousands separators

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -281,6 +281,10 @@ def extract_currency_symbol(
     return None
 
 
+# Characters used in place of ' as a thousands separator, e.g. in Swiss prices.
+_APOSTROPHES = re.compile("[’ʼ‘´`′]")
+
+
 def extract_price_text(price: str) -> Optional[str]:
     r"""
     Extract text of a price from a string which contains price and
@@ -317,10 +321,13 @@ def extract_price_text(price: str) -> Optional[str]:
     '1 298,00'
     >>> extract_price_text("$.75")
     '.75'
+    >>> extract_price_text("1’234.56")
+    '1234.56'
     """
     price = re.sub(
         r"\s+", " ", price
     )  # clean initial text from non-breaking and extra spaces
+    price = _APOSTROPHES.sub("'", price)
 
     if price.count("€") == 1:
         m = re.search(

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -102,6 +102,13 @@ PRICE_PARSING_EXAMPLES_NEW = [
     Example(None, "3,500円", "円", "3,500", 3500),
     Example(None, "CHF 1'049,95", "CHF", "1049,95", 1049.95),
     Example(None, "€1'049,95", "€", "1049,95", 1049.95),
+    Example(None, "CHF 1’049.95", "CHF", "1049.95", 1049.95),
+    Example(None, "CHF 1ʼ049.95", "CHF", "1049.95", 1049.95),
+    Example(None, "CHF 1´049.95", "CHF", "1049.95", 1049.95),
+    Example(None, "CHF 1′049.95", "CHF", "1049.95", 1049.95),
+    Example(None, "CHF 1‘049.95", "CHF", "1049.95", 1049.95),
+    Example(None, "CHF 1`049.95", "CHF", "1049.95", 1049.95),
+    Example(None, "CHF 1’049’950", "CHF", "1049950", 1049950),
     Example(None, "644.00 جنيه", "جنيه", "644.00", 644.0),  # Egyptian pound (EGP)
     Example(None, "3,439.00 درهم", "درهم", "3,439.00", 3439.0),  # UAE dirham (AED)
     Example(None, "106.61 ريال", "ريال", "106.61", 106.61),  # Saudi riyal (SAR)


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/price-parser/issues/61.