### PR TITLE
Only match alphabetic currency symbols on word boundaries

### DIFF
--- a/price_parser/parser.py
+++ b/price_parser/parser.py
@@ -75,9 +75,24 @@ class Price:
 parse_price = Price.fromstring
 
 
+_LETTER = r"[^\W\d_]"
+
+# Written as a prefix of a longer, inflected word ("руб" in "рублей").
+_PREFIX_SYMBOLS = {"руб", "грн", "лв", "тңг"}
+
+
+def _bounded(symbol: str) -> str:
+    pattern = re.escape(symbol)
+    if re.match(_LETTER, symbol):
+        pattern = f"(?<!{_LETTER}){pattern}"
+    if symbol not in _PREFIX_SYMBOLS and re.match(_LETTER, symbol[-1]):
+        pattern = f"{pattern}(?!{_LETTER})"
+    return pattern
+
+
 def or_regex(symbols: list[str]) -> Pattern[str]:
     """Return a regex which matches any of ``symbols``"""
-    return re.compile("|".join(re.escape(s) for s in symbols))
+    return re.compile("|".join(_bounded(s) for s in symbols))
 
 
 # If one of these symbols is found either in price or in currency,

--- a/tests/test_price_parsing.py
+++ b/tests/test_price_parsing.py
@@ -86,6 +86,15 @@ PRICE_PARSING_EXAMPLES_BUGS_CAUGHT = [
         decimal_separator=".",
         digit_group_separator=",",
     ),
+    # currency symbols within a longer word
+    Example(None, "EUROPE", None, None, None),
+    Example(None, "leisure activities", None, None, None),
+    Example(None, "Печная труба", None, None, None),
+    Example(">", "См. цену в прайсе", None, None, None),
+    Example(None, "Код товара: 884", None, "884", 884.0),
+    Example(None, "EUR 1", "EUR", "1", 1.0),
+    Example(None, "1EUR", "EUR", "1", 1.0),
+    Example(None, "1128240 рублей", "руб", "1128240", 1128240.0),
 ]
 
 
@@ -1242,10 +1251,6 @@ PRICE_PARSING_EXAMPLES_XFAIL = [
     Example("R273.00", "R273.00", "R", "273.00", 273),
     Example("R8,499", "R8,499", "R", "8,499", 8499),
     Example("Cuneo", "61.858 L", "L", "61.858", 61858),  # Romanian New Leu
-    # "р" / "руб" is detected as currency
-    Example(">", "См. цену в прайсе", None, None, None),
-    Example("Купить", "Печная труба", None, None, None),
-    Example(None, "Код товара: 884", None, "884", 884.0),
     # dates
     Example(None, "July, 2004", None, None, None),
     Example(None, "15.08.2017", None, None, None),


### PR DESCRIPTION
Fixes #12, closes https://github.com/scrapinghub/price-parser/pull/20, closes #78 (this is a superset of that one).